### PR TITLE
Preprocessor fixes

### DIFF
--- a/src/python/preprocessing.py
+++ b/src/python/preprocessing.py
@@ -31,10 +31,6 @@ def prune_graph(G, max_res, min_res):
             # returns number to use as weight for the algorithm
             return attr_dict['res_cost'][r]
 
-        def __get_weight_neg(i, j, attr_dict):
-            # returns number to use as weight for the algorithm
-            return -attr_dict['res_cost'][r]
-
         # Get paths from source to all other nodes
         length_s, path_s = single_source_bellman_ford(G,
                                                       'Source',

--- a/test/python/tests_preprocessing.py
+++ b/test/python/tests_preprocessing.py
@@ -14,13 +14,14 @@ class TestsPreprocessing(unittest.TestCase):
     """
 
     def setUp(self):
-        # Create digraph with negative resource costs with unreachable node 'B'
+        # Create digraph with negative resource costs with unreachable node 'E'
         self.G = DiGraph(directed=True, n_res=2)
         self.G.add_edge('Source', 'A', res_cost=array([1, 2]), weight=0)
         self.G.add_edge('A', 'C', res_cost=array([-1, 0.3]), weight=0)
         self.G.add_edge('A', 'B', res_cost=array([-1, 3]), weight=0)
-        # Unreachable node B
         self.G.add_edge('B', 'D', res_cost=array([-1, 2]), weight=0)
+        # Unreachable node E
+        self.G.add_edge('B', 'E', res_cost=array([10, 1]), weight=0)
         self.G.add_edge('C', 'D', res_cost=array([1, 0.1]), weight=0)
         self.G.add_edge('D', 'Sink', res_cost=array([1, 0.1]), weight=0)
 
@@ -32,12 +33,26 @@ class TestsPreprocessing(unittest.TestCase):
         self.H.add_edge('Sink', 'Source', weight=-1)
         self.max_res, self.min_res = ["foo"], ["bar"]
 
+        # Create digraph to test issue 72
+        self.F = DiGraph(n_res=1)
+        self.F.add_edge('Source', 'A', res_cost=array([1]), weight=1)
+        self.F.add_edge('A', 'B', res_cost=array([10]), weight=1)
+        self.F.add_edge('A', 'Sink', res_cost=array([1]), weight=1)
+
+
     def testUnreachable(self):
         """
-        Tests if the unreachable node 'B' is removed.
+        Tests if the unreachable node 'E' is removed.
         """
         self.G = preprocess_graph(self.G, [5, 20], [0, 0], True)
-        self.assertTrue('B' not in self.G.nodes())
+        self.assertTrue('E' not in self.G.nodes())
+
+    def testFindBadNode(self):
+        """
+        Tests if expensive node 'B' is removed
+        """
+        self.F = preprocess_graph(self.F, [5], [1], True)
+        self.assertTrue('B' not in self.F.nodes())
 
     def testFormatting(self):
         """


### PR DESCRIPTION
This PR fixes some of the logic with the Python `preprocessing.py`.  Previously it looked for both maximum and minimum constraint violations, but based on [this issue](https://github.com/torressa/cspy/issues/72#issuecomment-827939926), I don't think we can actually check the minimum constraint this way.

Another fix is ignoring the Source and Sink nodes when checking for violating nodes.  Previously we might have hit them early and missed violating nodes.

I also changed which node get identified as offending.  Given a shortest resource path from Source to A, if the cost is say 10 while our maximum allowed is 5, then A cannot possibly be on the shortest resource-constrained path from Source to Sink.  So we mark node A for removal.  Previously, the predecessor to node A was removed, think under logic that the final edge (i.e. B-A) was the problem.  But that could remove a node needed for other paths (see Issue #72 ).  Node identified changed from -2 to -1.

Finally, if the shortest path from Source to A consumes too many resources (i.e. node becomes a key in `nodes_source`), that is sufficient to remove that node.  Whether it also consumes too many from A to Sink becomes irrelevant (and vice versa) as it cannot be part of the shortest path.  If my logic is mixed up, I'd be happy to revert the changes I made.  `node in nodes_source and nodes_sink` changed to `node in nodes_source or node in nodes_sink` (note typo fix as well, was missing checking node in `nodes_sink`).