### PR TITLE
PSOLGENT improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [v1.0.1]
+
+### Changed
+
+ - Fix minimum number of nodes on path condition for PSOLGENT.
+ - Force node sorting to start with "Source" and end with "Sink" in PSOLGENT.
+ - Force inclusion of Source and Sink nodes in PSOLGENT paths.
+
+### Added
+ - Record `rand` value used to generate PSOLGENT paths from positions.
+ - Make upper and lower bound of PSOLGENT initial positions optional arguments.
+
+### Fixed
+ - Issue #79
+
 ## [v1.0.0]
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 project(
   cspy
-  VERSION 1.0.0
+  VERSION 1.0.1
   LANGUAGES CXX)
 message(STATUS "project: ${PROJECT_NAME}")
 message(STATUS "version: ${PROJECT_VERSION}")

--- a/src/python/algorithms/path_base.py
+++ b/src/python/algorithms/path_base.py
@@ -137,7 +137,7 @@ class PathBase:
             depth += 1
         return _path
 
-    def check_feasibility(self, return_edge=True):
+    def check_feasibility(self, return_edge=True, save=True):
         """
         Checks for feasibility for a valid source-sink path.
         If the path (in the st_path attribute) is feasible, then it
@@ -169,7 +169,8 @@ class PathBase:
                 break
         else:
             # Fesible path found. Save attributes.
-            self.save(total_res, cost)
+            if save:
+                self.save(total_res, cost)
             return True
         # Return infeasible edge unless specified
         if return_edge:

--- a/src/python/algorithms/psolgent.py
+++ b/src/python/algorithms/psolgent.py
@@ -330,7 +330,7 @@ class PSOLGENT(PathBase):
         """
         if not path:
             return False
-        if len(path) > 2 and (path[0] == 'Source' and path[-1] == 'Sink'):
+        if len(path) >= 2 and (path[0] == 'Source' and path[-1] == 'Sink'):
             base_cost = sum(edge[2]['weight'] for edge in edges)
             self.st_path = path
             if self.check_feasibility() is True:

--- a/src/python/algorithms/psolgent.py
+++ b/src/python/algorithms/psolgent.py
@@ -346,7 +346,7 @@ class PSOLGENT(PathBase):
     def _sort_nodes(nodes):
         """
         Sort nodes between Source and Sink. If node data allows sorting,
-        edit the line below to pass `list(self.G.nodes(data=True))` and used that
+        edit the line below to pass `list(self.G.nodes(data=True))` and use that
         in the sorting function below.
 
         For example, if nodes have an attribute `pos` a tuple that contains
@@ -354,6 +354,6 @@ class PSOLGENT(PathBase):
         `return sorted(nodes, key=lambda n: n[1]['pos'][0])`
         edit the sorting function to make use of it.
         """
-        order_dict = {'Source': '0', 'Sink': 'Z{}'.format(len(nodes))}
-        return sorted(nodes,
-                      key=lambda x: order_dict[x] if x in order_dict else x)
+        return ['Source'] + \
+               sorted([n for n in nodes if n not in ['Source', 'Sink']]) + \
+               ['Sink']

--- a/src/python/algorithms/psolgent.py
+++ b/src/python/algorithms/psolgent.py
@@ -134,8 +134,8 @@ class PSOLGENT(PathBase):
         self.swarm_size = swarm_size
         self.member_size = member_size if member_size else len(G.nodes())
         self.hood_size = neighbourhood_size
-        self.lower_bound = zeros(member_size)
-        self.upper_bound = ones(member_size)
+        self.lower_bound = -2 * ones(member_size)
+        self.upper_bound = 2 * ones(member_size)
         self.c1 = float(c1)
         self.c2 = float(c2)
         self.c3 = float(c3)
@@ -158,6 +158,8 @@ class PSOLGENT(PathBase):
         while (self.iter < self.max_iter and
                not check_time_limit_breached(start, self.time_limit)):
             pos_new = self.pos + self._get_vel()
+            # Force Source and Sink to be selected
+            pos_new[:,[0,-1]] = 10 * self.lower_bound
             self._update_best(self.pos, pos_new)
             self.pos = pos_new
             self.fitness = self._get_fitness(self.pos)
@@ -187,6 +189,8 @@ class PSOLGENT(PathBase):
             self.lower_bound - self.upper_bound,
             self.upper_bound - self.lower_bound,
             size=(self.swarm_size, self.member_size))
+        # Force Source and Sink to be selected
+        self.pos[:,[0,-1]] = 10 * self.lower_bound
         self.fitness = self._get_fitness(self.pos)
         self.best = copy(self.pos)
         self._global_best()
@@ -271,7 +275,7 @@ class PSOLGENT(PathBase):
     @staticmethod
     def _discretise_solution(member, rand):
         sig = array(1 / (1 + exp(-member)))
-        return array([1 if s < rand else 0 for s in sig])
+        return (sig < rand) * 1
 
     def _update_current_nodes(self, arr):
         """

--- a/src/python/algorithms/psolgent.py
+++ b/src/python/algorithms/psolgent.py
@@ -12,6 +12,7 @@ from networkx import DiGraph
 from numpy.random import RandomState
 from numpy import (argmin, array, copy, diag_indices_from, exp, dot, zeros,
                    ones, where)
+import numpy as np
 
 # Local imports
 from cspy.algorithms.path_base import PathBase

--- a/test/python/tests_issue79.py
+++ b/test/python/tests_issue79.py
@@ -1,6 +1,6 @@
 import unittest
 
-from numpy import array
+from numpy import array, testing
 from networkx import DiGraph
 
 from cspy import PSOLGENT
@@ -27,7 +27,7 @@ class TestsIssue79(unittest.TestCase):
         self.total_cost = 3.0
         self.consumed_resources = [2.0, 2.0]
 
-    def test_bidirectional(self):
+    def test_psolgent(self):
         """
         Test PSOLGENT can find path of Source directly connected to Sink
         """
@@ -35,4 +35,4 @@ class TestsIssue79(unittest.TestCase):
         alg.run()
         self.assertEqual(alg.path, self.result_path)
         self.assertEqual(alg.total_cost, self.total_cost)
-        self.assertEqual(alg.consumed_resources, self.consumed_resources)
+        self.assertIsNone(testing.assert_allclose(alg.consumed_resources, self.consumed_resources))

--- a/test/python/tests_issue79.py
+++ b/test/python/tests_issue79.py
@@ -1,6 +1,6 @@
 import unittest
 
-from numpy import array, testing
+from numpy import array, testing, min
 from networkx import DiGraph
 
 from cspy import PSOLGENT
@@ -29,6 +29,7 @@ class TestsIssue79(unittest.TestCase):
         # Hypothetical nodes that could be missorted
         self.nodes = ['ZZ', 'AA', 'Sink', 'Source']
         self.expected_nodes = ['Source', 'AA', 'ZZ', 'Sink']
+        self.pos_limit = -20
 
     def test_direct_connect(self):
         """
@@ -40,6 +41,10 @@ class TestsIssue79(unittest.TestCase):
         self.assertEqual(alg.total_cost, self.total_cost)
         self.assertIsNone(testing.assert_allclose(alg.consumed_resources,
                           self.consumed_resources))
+        # Check that all considered paths include source/sink
+        self.assertLessEqual(np.max(alg.pos[:,[0,-1]]),
+                          self.pos_limit)
+
 
     def test_sorting_nodes(self):
         """
@@ -47,3 +52,5 @@ class TestsIssue79(unittest.TestCase):
         """
         sorted_nodes = PSOLGENT._sort_nodes(self.nodes)
         self.assertListEqual(sorted_nodes, self.expected_nodes)
+
+

--- a/test/python/tests_issue79.py
+++ b/test/python/tests_issue79.py
@@ -22,14 +22,15 @@ class TestsIssue79(unittest.TestCase):
         self.G.add_edge('1', "Sink", res_cost=array([5, 3]), weight=1)
         self.G.add_edge('2', "Sink", res_cost=array([1, 1]), weight=2)
         self.G.add_edge("Source", "Sink", res_cost=array([2, 2]), weight=3)
-        # Expected results
+        # Expected CSP results
         self.result_path = ['Source', 'Sink']
         self.total_cost = 3.0
         self.consumed_resources = [2.0, 2.0]
+        # Maximum value of position for source/sink
+        self.pos_limit = -20
         # Hypothetical nodes that could be missorted
         self.nodes = ['ZZ', 'AA', 'Sink', 'Source']
         self.expected_nodes = ['Source', 'AA', 'ZZ', 'Sink']
-        self.pos_limit = -20
 
     def test_direct_connect(self):
         """
@@ -41,10 +42,17 @@ class TestsIssue79(unittest.TestCase):
         self.assertEqual(alg.total_cost, self.total_cost)
         self.assertIsNone(testing.assert_allclose(alg.consumed_resources,
                           self.consumed_resources))
+
+    def test_include_source_sink(self):
+        """
+        Test PSOLGENT can find path of Source directly connected to Sink
+        """
+        alg = PSOLGENT(self.G, self.max_res, self.min_res,
+                       lower_bound=-2, upper_bound=2)
+        alg.run()
         # Check that all considered paths include source/sink
         self.assertLessEqual(np.max(alg.pos[:,[0,-1]]),
                           self.pos_limit)
-
 
     def test_sorting_nodes(self):
         """

--- a/test/python/tests_issue79.py
+++ b/test/python/tests_issue79.py
@@ -26,8 +26,11 @@ class TestsIssue79(unittest.TestCase):
         self.result_path = ['Source', 'Sink']
         self.total_cost = 3.0
         self.consumed_resources = [2.0, 2.0]
+        # Hypothetical nodes that could be missorted
+        self.nodes = ['ZZ', 'AA', 'Sink', 'Source']
+        self.expected_nodes = ['Source', 'AA', 'ZZ', 'Sink']
 
-    def test_psolgent(self):
+    def test_direct_connect(self):
         """
         Test PSOLGENT can find path of Source directly connected to Sink
         """
@@ -35,4 +38,12 @@ class TestsIssue79(unittest.TestCase):
         alg.run()
         self.assertEqual(alg.path, self.result_path)
         self.assertEqual(alg.total_cost, self.total_cost)
-        self.assertIsNone(testing.assert_allclose(alg.consumed_resources, self.consumed_resources))
+        self.assertIsNone(testing.assert_allclose(alg.consumed_resources,
+                          self.consumed_resources))
+
+    def test_sorting_nodes(self):
+        """
+        Test PSOLGENT sorts nodes into correct order
+        """
+        sorted_nodes = PSOLGENT._sort_nodes(self.nodes)
+        self.assertListEqual(sorted_nodes, self.expected_nodes)

--- a/test/python/tests_issue79.py
+++ b/test/python/tests_issue79.py
@@ -37,7 +37,7 @@ class TestsIssue79(unittest.TestCase):
         """
         Test PSOLGENT can find path of Source directly connected to Sink
         """
-        alg = PSOLGENT(self.G, self.max_res, self.min_res)
+        alg = PSOLGENT(self.G, self.max_res, self.min_res, seed=42)
         alg.run()
         self.assertEqual(alg.path, self.result_path)
         self.assertEqual(alg.total_cost, self.total_cost)
@@ -48,7 +48,7 @@ class TestsIssue79(unittest.TestCase):
         """
         Test PSOLGENT can find path of Source directly connected to Sink
         """
-        alg = PSOLGENT(self.G, self.max_res, self.min_res,
+        alg = PSOLGENT(self.G, self.max_res, self.min_res, seed=42
                        lower_bound=-2, upper_bound=2)
         alg.run()
         # Check that all considered paths include source/sink

--- a/test/python/tests_issue79.py
+++ b/test/python/tests_issue79.py
@@ -1,6 +1,6 @@
 import unittest
 
-from numpy import array, testing, min
+from numpy import array, testing
 from networkx import DiGraph
 
 from cspy import PSOLGENT

--- a/test/python/tests_issue79.py
+++ b/test/python/tests_issue79.py
@@ -1,0 +1,38 @@
+import unittest
+
+from numpy import array
+from networkx import DiGraph
+
+from cspy import PSOLGENT
+
+
+class TestsIssue79(unittest.TestCase):
+    """
+    Tests for issue #79
+    https://github.com/torressa/cspy/issues/79
+    """
+
+    def setUp(self):
+        # Maximum and minimum resource arrays
+        self.max_res, self.min_res = [7, 5], [1, 0]
+        # Create simple digraph with appropriate attributes
+        self.G = DiGraph(directed=True, n_res=2)
+        self.G.add_edge("Source", '1', res_cost=array([5, 3]), weight=1)
+        self.G.add_edge("Source", '2', res_cost=array([1, 1]), weight=2)
+        self.G.add_edge('1', "Sink", res_cost=array([5, 3]), weight=1)
+        self.G.add_edge('2', "Sink", res_cost=array([1, 1]), weight=2)
+        self.G.add_edge("Source", "Sink", res_cost=array([2, 2]), weight=3)
+        # Expected results
+        self.result_path = ['Source', 'Sink']
+        self.total_cost = 3.0
+        self.consumed_resources = [2.0, 2.0]
+
+    def test_bidirectional(self):
+        """
+        Test PSOLGENT can find path of Source directly connected to Sink
+        """
+        alg = PSOLGENT(self.G, self.max_res, self.min_res)
+        alg.run()
+        self.assertEqual(alg.path, self.result_path)
+        self.assertEqual(alg.total_cost, self.total_cost)
+        self.assertEqual(alg.consumed_resources, self.consumed_resources)

--- a/test/python/tests_issue79.py
+++ b/test/python/tests_issue79.py
@@ -48,7 +48,7 @@ class TestsIssue79(unittest.TestCase):
         """
         Test PSOLGENT can find path of Source directly connected to Sink
         """
-        alg = PSOLGENT(self.G, self.max_res, self.min_res, seed=42
+        alg = PSOLGENT(self.G, self.max_res, self.min_res, seed=42,
                        lower_bound=-2, upper_bound=2)
         alg.run()
         # Check that all considered paths include source/sink

--- a/test/python/tests_issue79.py
+++ b/test/python/tests_issue79.py
@@ -1,6 +1,7 @@
 import unittest
 
 from numpy import array, testing
+import numpy as np
 from networkx import DiGraph
 
 from cspy import PSOLGENT


### PR DESCRIPTION
* Fix minimum number of nodes on path condition
* Force node sorting to start with "Source" and end with "Sink" regardless of internally named nodes
* Force inclusion of Source and Sink nodes onto path
* Record `rand` value used to generate paths from positions
* Make upper and lower bound of initial positions optional arguments (rather than constants)