### PR TITLE
False 2-cycle elimination #108

### DIFF
--- a/src/cc/bidirectional.h
+++ b/src/cc/bidirectional.h
@@ -109,6 +109,10 @@ class BiDirectional {
     params_ptr_->setElementary(elementary_in);
   }
   /// @see bidirectional::Params
+  void setTwoCycleElimination(const bool& two_cycle_elimination_in) {
+    params_ptr_->setTwoCycleElimination(two_cycle_elimination_in);
+  }
+  /// @see bidirectional::Params
   void setBoundsPruning(const bool& bounds_pruning_in) {
     params_ptr_->setBoundsPruning(bounds_pruning_in);
   }

--- a/src/cc/labelling.cc
+++ b/src/cc/labelling.cc
@@ -156,7 +156,51 @@ bool Label::checkStPath(const int& source_id, const int& sink_id) const {
 }
 
 bool Label::checkPathExtension(const int& user_id) const {
-  return (partial_path.end()[-2] != user_id && partial_path.back() != user_id);
+  if (partial_path.back() == user_id) {
+    return false;
+  };
+
+  if (params_ptr->two_cycle_elimination && getPredecessorId() == user_id) {
+    return false;
+  }
+
+  return true;
+}
+
+bool Label::checkSameFeasibleExtensionTwoCycleSimple(const Label& other) const {
+  return other.partial_path.size() > 1 && partial_path.size() > 1 &&
+         other.getPredecessorId() == getPredecessorId();
+}
+
+bool Label::checkSameFeasibleExtensionElementary(const Label& other) const {
+  if (unreachable_nodes.size() == 0)
+    return false;
+
+  if (other.unreachable_nodes.size() == 0)
+    return false;
+
+  if (!std::includes(
+          other.unreachable_nodes.begin(),
+          other.unreachable_nodes.end(),
+          unreachable_nodes.begin(),
+          unreachable_nodes.end())) {
+    return false;
+  }
+
+  return true;
+}
+
+bool Label::checkSameFeasibleExtension(const Label& other) const {
+  if (params_ptr->elementary) {
+    return checkSameFeasibleExtensionElementary(other);
+  }
+
+  if (params_ptr->two_cycle_elimination) {
+    return checkSameFeasibleExtensionTwoCycleSimple(other);
+  }
+
+  // always same extension if RCSPP without cycle-elimination
+  return true;
 }
 
 bool Label::checkDominance(
@@ -203,19 +247,12 @@ bool Label::checkDominance(
       }
     }
   }
-  // Check for the elementary case
-  if (params_ptr->elementary && unreachable_nodes.size() > 0 &&
-      other.unreachable_nodes.size() > 0) {
-    // check other.unreachable_nodes \subset unreachable_nodes (strict)
-    if (!std::includes(
-            other.unreachable_nodes.begin(),
-            other.unreachable_nodes.end(),
-            unreachable_nodes.begin(),
-            unreachable_nodes.end())) {
-      return false;
-    }
+
+  if (!checkSameFeasibleExtension(other)) {
+    return false;
   }
-  //  this dominates other
+
+  // this dominates other
   return true;
 }
 
@@ -403,32 +440,35 @@ bool mergePreCheck(
     const labelling::Label&    fwd_label,
     const labelling::Label&    bwd_label,
     const std::vector<double>& max_res) {
-  bool result = true;
   if (fwd_label.vertex.lemon_id == -1 || bwd_label.vertex.lemon_id == -1)
     return false;
 
   // Merge paths
-  std::vector<int> path     = fwd_label.partial_path;
-  std::vector<int> path_bwd = bwd_label.partial_path;
-
-  std::reverse(path_bwd.begin(), path_bwd.end());
-  path.insert(path.end(), path_bwd.begin(), path_bwd.end());
+  std::vector<int> path = fwd_label.partial_path;
+  path.insert(
+      path.end(),
+      bwd_label.partial_path.rbegin(),
+      bwd_label.partial_path.rend());
 
   if (fwd_label.params_ptr->elementary) {
     std::sort(path.begin(), path.end());
     const bool& contains_duplicates =
         std::adjacent_find(path.begin(), path.end()) != path.end();
-    result = !contains_duplicates;
+    return !contains_duplicates;
   }
 
   // Check for 2-cycles.
-  const int size = static_cast<int>(path.size());
-  for (int i = 1; i < size - 1; ++i) {
-    if (path[i - 1] == path[i + 1] || path[i - 1] == path[i])
+  // Check at end of partial path should be sufficient since individual paths
+  // are 2-cycle free
+  if (fwd_label.params_ptr->two_cycle_elimination) {
+    if (fwd_label.getPredecessorId() == bwd_label.partial_path.back())
+      return false;
+
+    if (bwd_label.getPredecessorId() == fwd_label.partial_path.back())
       return false;
   }
 
-  return result;
+  return true;
 }
 
 Label mergeLabels(

--- a/src/cc/labelling.h
+++ b/src/cc/labelling.h
@@ -145,8 +145,41 @@ class Label {
   /// Returns true is the partial path extension is OK.
   bool checkPathExtension(const int& user_id) const;
 
+  /**
+   * Simple check if both lables have the same feasible extension with regard to
+   * 2-cycle elimination.
+   * this and other have same feasible extension if predecessor is the same.
+   * @param[in] other, Label with other label to compare
+   * @return true if this and other have same feasible extension
+   */
+  bool checkSameFeasibleExtensionTwoCycleSimple(const Label& other) const;
+
+  /**
+   * Simple check if both lables have the same feasible extension under
+   * elementary conditions.
+   * this and other have the same feasible extension if unreachable_nodes of
+   * this is subset of unreachable_nodes of other
+   * @param[in] other, Label with other label to compare
+   * @return true if this and other have same feasible extension
+   */
+  bool checkSameFeasibleExtensionElementary(const Label& other) const;
+
+  /**
+   * Check if both lables have the same feasible extension, i.e.,
+   * if they both can extend to the same nodes.
+   * Important for correct dominance check.
+   * Labels with different feasible extension cannot dominate each other.
+   * @param[in] other, Label with other label to compare
+   * @return true if this and other have same feasible extension
+   */
+  bool checkSameFeasibleExtension(const Label& other) const;
+
   /// set phi attribute for merged labels from Righini and Salani (2006)
   void setPhi(const double& phi_in) { phi = phi_in; }
+
+  /// gets the id of the predecessor node
+  /// TODO can be replaced as member of label
+  int getPredecessorId() const { return partial_path.end()[-2]; };
 
   std::string getString() const;
   // operator overloads

--- a/src/cc/params.h
+++ b/src/cc/params.h
@@ -36,6 +36,8 @@ class Params {
   double threshold = std::nan("na");
   /// bool with whether output path is required to be elementary
   bool elementary = false;
+  /// bool with wheter 2-cycles should be eliminated for non-elementary RCSPP
+  bool two_cycle_elimination = false;
   /// bool with whether lower bounds based on shortest paths are used to prune
   /// labels. Experimental!
   bool bounds_pruning = false;
@@ -69,6 +71,9 @@ class Params {
   void setTimeLimit(const double& time_limit_in) { time_limit = time_limit_in; }
   void setThreshold(const double& threshold_in) { threshold = threshold_in; }
   void setElementary(const bool& elementary_in) { elementary = elementary_in; }
+  void setTwoCycleElimination(const bool& two_cycle_elimination_in) {
+    two_cycle_elimination = two_cycle_elimination_in;
+  };
   void setBoundsPruning(const bool& bounds_pruning_in) {
     bounds_pruning = bounds_pruning_in;
   }


### PR DESCRIPTION
Basic implementation for feasible extension check if 2-cycles elimination is enabled in RCSPP. Fix for #108. Commit adds a parameter two_cycle_elimination to disable/enable 2-cycle elimination.